### PR TITLE
refac: Still trying to trigger update of that buggy third-party style…

### DIFF
--- a/birdsongs/src/Components/Search/Search.js
+++ b/birdsongs/src/Components/Search/Search.js
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import Dropdown from 'react-dropdown';
 import dropdownOptions from '../../dropdownOptions.js';
-import 'react-dropdown/styles.css';
+import 'react-dropdown/style.css';
 import './Search.css';
 
 // component

--- a/birdsongs/src/Components/Search/Search.js
+++ b/birdsongs/src/Components/Search/Search.js
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import Dropdown from 'react-dropdown';
 import dropdownOptions from '../../dropdownOptions.js';
-import '../../../node_modules/react-dropdown/styles.css';
+import 'react-dropdown/styles.css';
 import './Search.css';
 
 // component

--- a/birdsongs/src/Components/Search/Search.js
+++ b/birdsongs/src/Components/Search/Search.js
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import Dropdown from 'react-dropdown';
 import dropdownOptions from '../../dropdownOptions.js';
-import '../../../node_modules/react-dropdown/styless.css';
+import '../../../node_modules/react-dropdown/styles.css';
 import './Search.css';
 
 // component


### PR DESCRIPTION
## Describe your changes:
**Third-party stylesheet for dropdown menu**: Fixed issue I've been encountering with this filepath, but only in regards to deployed site. 

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have tested the functionality of any new or updated features in the browser, if applicable
- [x] I have added a "Reviewer" to review & merge
- [x] If applicable, my code passes all tests

## Notes:
Everything has been and continues to work fine locally. The only fix I could find was re-installing the third party library via npm, and now the styled dropdown menu is only present in the local environment, and not in the test environment. I'm choosing to let this go for now. 