### PR TITLE
refac: Alter struture of fixture json files to correctly simulate dat…

### DIFF
--- a/birdsongs/cypress/e2e/Search.cy.js
+++ b/birdsongs/cypress/e2e/Search.cy.js
@@ -1,94 +1,97 @@
-{describe('Search functionality', () => {
-    beforeEach(() => {
-      cy.intercept('GET', 'https://xeno-canto.org/api/2/recordings?query=loc:Illinois+"goose"', {
+describe('Search functionality', () => {
+  beforeEach(() => {
+    cy.fixture('./xc-data.json').then((data) => {
+      cy.intercept('GET', `https://xeno-canto.org/api/2/recordings?query=loc:Illinois+goose`, {
         statusCode: 200,
-        fixture: 'xc-data.json'
-      });
-      cy.visit('http://localhost:3000/search');
+        body: data
+      }).as('getRecordings');
     });
-    
-    it('User should see a search form', () => {
-      cy.get('.search-description').first().contains("Start by selecting a state to explore from the menu below.")
+    cy.visit('http://localhost:3000/search');
+  });
+
+  it('User should see a search form', () => {
+    cy.get('.search-description').first().contains("Start by selecting a state to explore from the menu below.")
       .get('.location-field').contains("Choose your state")
       .get('.search-description').last().contains("Looking for a specific bird?")
-      .get('.query-field').and('have.attr', 'placeholder').and('include', 'Common name')
-    });
+      .get('.query-field').and('have.attr', 'placeholder').and('include', 'Common name');
+  });
 
-    it('Search button should be disabled on page load', () => {
-      cy.get('#search-button').should('not.exist');
-    });
-
-    it('Search button should be enabled when location field has value', () => {
-      cy.get('.location-field').click().get('.Dropdown-menu').contains("Illinois").click()
+  it('Search button should be disabled on page load', () => {
+    cy.get('#search-button').should('not.exist');
+  });
+  it('Search button should be enabled when location field has value', () => {
+    cy.get('.location-field').click().get('.Dropdown-menu').contains("Illinois").click()
       .get('.location-field').contains("Illinois")
       .get('#search-button').should('be.visible');
-    });
-
-    it('User should be able to search birdsongs by location and query', () => {
-      cy.get('.location-field').click().get('.Dropdown-menu').contains("Illinois").click()
+  });
+  it('User should be able to search birdsongs by location and query', () => {
+    cy.get('.location-field').click().get('.Dropdown-menu').contains("Illinois").click()
       .get('.query-field').type("goose")
       .get('#search-button').click()
       .get('.common-name').contains("Canada Goose")
       .get('.scientific-name').contains("Canadensis")
       .get('.specific-location').contains("Midewin Tallgrass Prairie, Will County")
-      .get('.audio').should('have.attr', 'src').and('include', "https://xeno-canto.org/391178/download")
-    });
+      .get('.audio').should('have.attr', 'src').and('include', "https://xeno-canto.org/391178/download");
+  });
 
-    it('When clicked, the NEW SEARCH button should navigate back to the search page', () => {
-      cy.get('.location-field').click().get('.Dropdown-menu').contains("Illinois").click()
+  it('When clicked, the NEW SEARCH button should navigate back to the search page', () => {
+    cy.get('.location-field').click().get('.Dropdown-menu').contains("Illinois").click()
       .get('.query-field').type("goose")
       .get('#search-button').click()
-      .get('#new-search-button').click().url().should('eq', 'http://localhost:3000/search')
-    });
+      .get('#new-search-button').click().url().should('eq', 'http://localhost:3000/search');
+  });
 
-    it('When a recording is clicked, user should see additional details', () => {
-      cy.visit('http://localhost:3000/search')
+  it('When a recording is clicked, user should see additional details', () => {
+    cy.visit('http://localhost:3000/search')
       .get('.location-field').click().get('.Dropdown-menu').contains("Illinois").click()
       .get('.query-field').type("goose");
+    cy.fixture('single-xc-data.json').then((data) => {
       cy.intercept('GET', 'https://xeno-canto.org/api/2/recordings?query=nr+391178', {
         statusCode: 200,
-        fixture: 'single-xc-data.json'
+        body: data
       });
-      cy.get('#search-button').click()
+    });
+    cy.get('#search-button').click()
       .get('.common-name').contains("Canada Goose").click()
       .get('.selected-common-name').contains("Canada Goose")
       .get('#selected-date').contains("Recorded on October 17, 2017")
       .get('#selected-recordist').contains("by Greg Irving")
-      .get('#selected-remark').contains("I assume these are Canada and not Cackling, but not seen clearly enough to say for sure. Flock of 30-40 migrating individuals.")
-    });
+      .get('#selected-remark').contains("I assume these are Canada and not Cackling, but not seen clearly enough to say for sure. Flock of 30-40 migrating individuals");
+  });
 
-    it('User should be notified of failed network request', () => {
-      cy.get('.location-field').click().get('.Dropdown-menu').contains('Illinois').click();
-      cy.get('.query-field').type('goose');
-      cy.intercept('GET', 'https://xeno-canto.org/api/2/recordings?query=loc:Illinois+goose', {
-        statusCode: 500,
-      });
-      cy.get('#search-button').click();
-      cy.get('p').contains("Something's gone wrong on our end.");
+  it('User should be notified of failed network request', () => {
+    cy.get('.location-field').click().get('.Dropdown-menu').contains('Illinois').click();
+    cy.get('.query-field').type('goose');
+    cy.intercept('GET', 'https://xeno-canto.org/api/2/recordings?query=loc:Illinois+goose', {
+      statusCode: 500,
     });
-
-    it('User should be notified upon search with no results', () => {
-      cy.get('.location-field').click().get('.Dropdown-menu').contains('Illinois').click()
+    cy.get('#search-button').click();
+    cy.get('p').contains("Something's gone wrong on our end.");
+  });
+  it('User should be notified upon search with no results', () => {
+    cy.get('.location-field').click().get('.Dropdown-menu').contains('Illinois').click()
       .get('.query-field').type('sillygoose');
-      cy.intercept('GET', 'https://xeno-canto.org/api/2/recordings?query=loc:Illinois+"sillygoose"', {
+    cy.fixture('bad-xc-data.json').then((data) => {
+      cy.intercept('GET', 'https://xeno-canto.org/api/2/recordings?query=loc:Illinois+sillygoose', {
         statusCode: 200,
-        fixture: 'bad-xc-data.json'
-        });
-      cy.get('#search-button').click()
-      .get('.error-container')
-      .get('h3').contains("Looks like you're on a wild goose chase. There are no results for that bird. Check for typos, or try broadening your search term.")
+        body: data
+      });
     });
+    cy.get('#search-button').click()
+      .get('.error-container')
+      .get('h3').contains("Looks like you're on a wild goose chase. There are no results for that bird. Check for typos, or try broadening your search term.");
+  });
 
-    it('The BACK button should return users to the homepage', () => {
-      cy.intercept('GET', 'https://xeno-canto.org/api/2/recordings?query=loc:Illinois+"sillygoose"', {
-          statusCode: 200,
-          fixture: 'bad-xc-data.json'
-      })
-      .visit('http://localhost:3000/search')
-      .get('.location-field').click().get('.Dropdown-menu').contains('Illinois').click()
+  it('The BACK button should return users to the homepage', () => {
+    cy.fixture('bad-xc-data.json').then((data) => {
+      cy.intercept('GET', 'https://xeno-canto.org/api/2/recordings?query=loc:Illinois+sillygoose', {
+        statusCode: 200,
+        body: data
+      });
+    });
+      cy.get('.location-field').click().get('.Dropdown-menu').contains('Illinois').click()
       .get('.query-field').type('sillygoose')
       .get('#search-button').click()
-      .get('#back-button').click().url().should('eq', 'http://localhost:3000/search')
-    });
-  })
-}
+      .get('#back-button').click().url().should('eq', 'http://localhost:3000/search');
+  });
+});

--- a/birdsongs/cypress/fixtures/bad-xc-data.json
+++ b/birdsongs/cypress/fixtures/bad-xc-data.json
@@ -1,1 +1,7 @@
-[]
+{
+  "numRecordings": "0",
+  "numSpecies": "0",
+  "page": 1,
+  "numPages": 1,
+  "recordings": []
+  }

--- a/birdsongs/cypress/fixtures/single-xc-data.json
+++ b/birdsongs/cypress/fixtures/single-xc-data.json
@@ -1,4 +1,9 @@
-[
+{
+  "numRecordings": "1",
+  "numSpecies": "1",
+  "page": 1,
+  "numPages": 1,
+  "recordings": [
   {
   "id": "391178",
   "gen": "Branta",
@@ -48,4 +53,5 @@
   "mic": "",
   "smp": "48000"
   }
-]
+  ]
+  }

--- a/birdsongs/cypress/fixtures/xc-data.json
+++ b/birdsongs/cypress/fixtures/xc-data.json
@@ -1,4 +1,9 @@
-[
+{
+  "numRecordings": "4",
+  "numSpecies": "3",
+  "page": 1,
+  "numPages": 1,
+  "recordings": [
   {
   "id": "391178",
   "gen": "Branta",
@@ -199,4 +204,5 @@
   "mic": "",
   "smp": "44100"
   }
-]
+  ]
+  }


### PR DESCRIPTION
** I fully pushed this branch on Sunday night (6/11), just to be clear. While prepping for the final assessment, I revisited these tests after realizing that a solid green circle was not, in fact, was I was actually aiming for with a correct intercept+stub and worked to get them corrected. This really helped my own understanding-- I hope that's okay! 

## Describe your changes:
**Search spec, .json files referenced in search spec**: I changed the structure of the .json files to correctly stub the data, which I realize was my issue all along. I kept thinking it was an issue with the links. I changed the links back to their original states. 

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have tested the functionality of any new or updated features in the browser, if applicable
- [x] I have added a "Reviewer" to review & merge
- [x] If applicable, my code passes all tests